### PR TITLE
Fix DOI resolver pattern for full URL

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,4 @@ Contributors
 ------------
 
 * Trent Hare <thare@usgs.gov>
+* Benoît Seignovert <benoit.seignovert@univ-nantes.fr>

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,14 @@
-### Add pandas in requirements.txt Update to python 3.10 Fix the calculation of the radius when the approxmation is selected. (HEAD -> main)
+### Fix DOI resolver pattern for full URL (HEAD -> fix-doi-url)
+>Tue, 6 Dec 2022 16:58:07 +0100
+
+>Author: Benoit Seignovert (benoit.seignovert@univ-nantes.fr)
+
+>Commiter: Benoit Seignovert (benoit.seignovert@univ-nantes.fr)
+
+
+
+
+### Add pandas in requirements.txt Update to python 3.10 Fix the calculation of the radius when the approxmation is selected. (origin/main, origin/HEAD, main)
 >Tue, 11 Oct 2022 00:02:05 +0200
 
 >Author: Jean-Christophe Malapert (Jean-christophe.malapert@cnes.fr)
@@ -8,7 +18,7 @@
 
 
 
-### Fix typo (origin/main, origin/HEAD)
+### Fix typo
 >Fri, 13 May 2022 22:37:54 +0200
 
 >Author: Jean-Christophe Malapert (jean-christophe.malapert@cnes.fr)

--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ To use csvForWKT:
     .. code-block:: console
 
         $ make
-        $ csvforwkt --iau_report data/naifcodes_radii_m_wAsteroids_IAU2015.csv --iau_version 2015 --iau_doi doi://10.1007/s10569-017-9805-5
+        $ csvforwkt --iau_report data/naifcodes_radii_m_wAsteroids_IAU2015.csv --iau_version 2015 --iau_doi https://doi.org/10.1007/s10569-017-9805-5
 
 
 Run tests

--- a/csvforwkt/__main__.py
+++ b/csvforwkt/__main__.py
@@ -106,7 +106,7 @@ def parse_cli() -> argparse.Namespace:
     parser.add_argument(
         "--iau_doi",
         required=True,
-        help="DOI of the IAU report (ex: doi://10.1007/s10569-017-9805-5)",
+        help="DOI of the IAU report (ex: https://doi.org/10.1007/s10569-017-9805-5)",
     )
 
     parser.add_argument(
@@ -133,7 +133,7 @@ def parse_cli() -> argparse.Namespace:
 
 
 def run():
-    """Main function that instanciates the library."""
+    """Main function that instantiates the library."""
     handler = SigintHandler()
     signal.signal(signal.SIGINT, handler.signal_handler)
     try:

--- a/csvforwkt/body.py
+++ b/csvforwkt/body.py
@@ -13,7 +13,7 @@ class IAU_REPORT:  # pylint: disable=invalid-name,too-few-public-methods
     """Version of the IAU report."""
 
     VERSION: str = "2015"
-    DOI_IAU: str = "doi://10.1007/s10569-017-9805-5"
+    DOI_IAU: str = "https://doi.org/10.1007/s10569-017-9805-5"
     SOURCE_IAU: str = "Source of IAU Coordinate systems: " + DOI_IAU
 
 

--- a/docs/source/getting_starting.rst
+++ b/docs/source/getting_starting.rst
@@ -19,6 +19,6 @@ Running the software
 
 .. code-block:: shell
 
-    csvforwkt --iau_report data/naifcodes_radii_m_wAsteroids_IAU2015.csv --iau_version 2015 --iau_doi doi://10.1007/s10569-017-9805-5
+    csvforwkt --iau_report data/naifcodes_radii_m_wAsteroids_IAU2015.csv --iau_version 2015 --iau_doi https://doi.org/10.1007/s10569-017-9805-5
 
 This will generate the file iau.wkt with all WKTs.

--- a/tests/csvforwkt_test.py
+++ b/tests/csvforwkt_test.py
@@ -23,7 +23,7 @@ def pytest_namespace():
 def data():
     iau_data = "data/naifcodes_radii_m_wAsteroids_IAU2015.csv"
     iau_version = 2015
-    iau_doi = "doi://10.1007/s10569-017-9805-5"
+    iau_doi = "https://doi.org/10.1007/s10569-017-9805-5"
     csv2wkt = CsvforwktLib(iau_data, iau_version, iau_doi, "/tmp")
     pytest.crs = csv2wkt.process()
 


### PR DESCRIPTION
Resolves #2 

DOI resolver pattern should either be:
```
https://doi.org/10.xxx
```
or
```
doi:10.xxx
```
(see [DOI docs](https://www.doi.org/doi_handbook/3_Resolution.html))

The latter pattern requires an extension in most web browsers, therefore the first pattern is recommanded.